### PR TITLE
Prevent prefetching if layer is not visible.

### DIFF
--- a/new-radar/package.json
+++ b/new-radar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exb-new-radar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "This is a simple widget to add a looping radar and controls to an existing map widget.",
   "author": "Lucius Creamer",
   "license": "MIT",

--- a/new-radar/src/runtime/widget.tsx
+++ b/new-radar/src/runtime/widget.tsx
@@ -236,6 +236,7 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
 					if (panZoomTimerRef.current) clearTimeout(panZoomTimerRef.current)
 					panZoomTimerRef.current = setTimeout(async () => {
 						if (prefetchInProgressRef.current) return
+						if (wmsRef.current && !wmsRef.current.visible) return
 						const key = getExtentKey(view)
 						if (!key || key === prevExtentKeyRef.current) return
 


### PR DESCRIPTION
Updated new-radar widget to improve performance when the radar is no longer visible and the map is panned. The widget now checks the layer visibility before pre-fetching tiles.