### PR TITLE
Updated ABLS to enable a layers list.

### DIFF
--- a/ABLS/config.json
+++ b/ABLS/config.json
@@ -1,3 +1,4 @@
 {
-  "views": []
+  "views": [],
+  "expandEnabled": false
 }

--- a/ABLS/manifest.json
+++ b/ABLS/manifest.json
@@ -7,7 +7,7 @@
   "author": "Lucius Creamer MOSEMA",
   "description": "This widget allows for users to toggle between pre-configured layer visibility views, allowing for quick and easy layer toggling without reloading the entire page.",
   "copyright": "",
-  "license": "http://www.apache.org/licenses/LICENSE-2.0",
+  "license": "MIT",
   "properties": {
     "hasSettingPage": true,
     "hasStylePage": false,

--- a/ABLS/package.json
+++ b/ABLS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abls",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A Better Layer Switcher - A custom Experience Widget, to swith between sets of layers using a views navigation like interface.",
   "keywords": [
     "exb-widget",

--- a/ABLS/src/config.ts
+++ b/ABLS/src/config.ts
@@ -11,10 +11,12 @@ export interface ABLSView {
   startOffset?: number;
   endOffset?: number;
   tod?: number;
+  expandLayerIds?: string[]; //Array of layer IDs that should be shown when expanded
 }
 
 // Defines the overall widget configuration
 export interface Config {
+  expandEnabled?: boolean;
   views: ABLSView[];
 }
 

--- a/ABLS/src/runtime/style.css
+++ b/ABLS/src/runtime/style.css
@@ -18,3 +18,25 @@
   /* Ensure the label doesn't wrap inside the button and stays readable */
   white-space: nowrap;
 }
+
+.widget-abls .expand-handle-icon {
+  margin-left: 4px;
+  vertical-align: middle;
+  opacity: 0.75;
+}
+
+/* Wrapper that anchors the measurement ref */
+.view-buttons-wrapper {
+  position: relative;
+}
+
+/* Floating layer list rendered via portal into document.body */
+.expanded-layers-list {
+  position: fixed;
+  min-width: 220px;
+  max-width: 360px;
+  width: max-content;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 9999;
+}

--- a/ABLS/src/runtime/widget.tsx
+++ b/ABLS/src/runtime/widget.tsx
@@ -25,6 +25,8 @@ export default function Widget (props: AllWidgetProps<Config>) {
 	const [visibleLayers, setVisibleLayers] = React.useState<Layer[]>([])
 	const [listStyle, setListStyle] = React.useState<React.CSSProperties>({})
 	const buttonsWrapperRef = React.useRef<HTMLDivElement>(null)
+	const listRef = React.useRef<any>(null)
+	const focusButtonOnCollapseRef = React.useRef(false)
 
 	// This is the way that the widget prevents itself from running itself, and from crashing. It checks to see if any maps have been selected, and if any views have been configured.
 	const isConfigured = useMapWidgetIds?.length > 0 && config.views?.length > 0
@@ -119,6 +121,18 @@ export default function Widget (props: AllWidgetProps<Config>) {
 		[jimuMapView]
 	)
 
+	const focusActiveButton = useCallback(() => {
+		if (!activeViewId || !buttonsWrapperRef.current) return
+		const btn = buttonsWrapperRef.current.querySelector(`[data-view-id="${activeViewId}"]`)
+		if (!btn) return
+		const setFocusFn = Reflect.get(btn, 'setFocus')
+		if (typeof setFocusFn === 'function') {
+			setFocusFn.call(btn)
+		} else if (btn instanceof HTMLElement) {
+			btn.focus()
+		}
+	}, [activeViewId])
+
 	React.useEffect(() => {
 		if (expand && buttonsWrapperRef.current) {
 			const rect = buttonsWrapperRef.current.getBoundingClientRect()
@@ -132,6 +146,87 @@ export default function Widget (props: AllWidgetProps<Config>) {
 			)
 		}
 	}, [expand])
+
+	// Focus the first list item shortly after the list opens
+	React.useEffect(() => {
+		if (!expand) return
+		const timer = setTimeout(() => {
+			const firstItem = listRef.current?.querySelector('calcite-list-item')
+			firstItem?.setFocus?.()
+		}, 50)
+		return () => { clearTimeout(timer) }
+	}, [expand])
+
+	// Keyboard navigation: Escape closes the list; ArrowDown on the last item returns focus to the active button
+	React.useEffect(() => {
+		const el = listRef.current
+		if (!expand || !el) return
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				e.stopPropagation()
+				focusButtonOnCollapseRef.current = true
+				setExpand(false)
+				setExpandedLayers([])
+				setVisibleLayers([])
+				return
+			}
+			if (e.key === 'ArrowDown') {
+				const allItems = Array.from(el.querySelectorAll('calcite-list-item'))
+				const lastItem = allItems[allItems.length - 1]
+				if (lastItem && document.activeElement === lastItem) {
+					e.preventDefault()
+					focusActiveButton()
+				}
+			}
+		}
+		el.addEventListener('keydown', handleKeyDown, true)
+		return () => { el.removeEventListener('keydown', handleKeyDown, true) }
+	}, [expand, focusActiveButton])
+
+	// ArrowUp on the active button navigates to the last item in the open list
+	React.useEffect(() => {
+		if (!expand || !buttonsWrapperRef.current) return
+		const wrapper = buttonsWrapperRef.current
+		const handleButtonKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'ArrowUp') return
+			const target = e.target as HTMLElement
+			if (!target.closest(`[data-view-id="${activeViewId}"]`)) return
+			const allItems = Array.from(listRef.current?.querySelectorAll('calcite-list-item') ?? [])
+			const lastItem = allItems[allItems.length - 1] as any
+			if (lastItem) {
+				e.preventDefault()
+				lastItem.setFocus?.()
+			}
+		}
+		wrapper.addEventListener('keydown', handleButtonKeyDown, true)
+		return () => { wrapper.removeEventListener('keydown', handleButtonKeyDown, true) }
+	}, [expand, activeViewId])
+
+	// Click outside both the list and the buttons wrapper collapses the list
+	React.useEffect(() => {
+		if (!expand) return
+		const handleClickOutside = (e: MouseEvent) => {
+			const target = e.target as Node
+			if (
+				!(listRef.current?.contains(target)) &&
+				!(buttonsWrapperRef.current?.contains(target))
+			) {
+				setExpand(false)
+				setExpandedLayers([])
+				setVisibleLayers([])
+			}
+		}
+		document.addEventListener('mousedown', handleClickOutside)
+		return () => { document.removeEventListener('mousedown', handleClickOutside) }
+	}, [expand])
+
+	// After a collapse-with-focus was requested, focus the active button once the list unmounts
+	React.useEffect(() => {
+		if (!expand && focusButtonOnCollapseRef.current) {
+			focusButtonOnCollapseRef.current = false
+			focusActiveButton()
+		}
+	}, [expand, focusActiveButton])
 
 	React.useEffect(() => {
 		// Check if the map is loaded, if views are configured, and if no view is active yet.
@@ -210,6 +305,7 @@ export default function Widget (props: AllWidgetProps<Config>) {
 			<div className="view-buttons-wrapper" ref={buttonsWrapperRef}>
 				{expand && expandedLayers.length > 0 && ReactDOM.createPortal(
 					<calcite-list
+						ref={listRef}
 						label="Expanded Layers"
 						className="expanded-layers-list"
 						selectionMode="multiple"
@@ -227,6 +323,7 @@ export default function Widget (props: AllWidgetProps<Config>) {
 						) => (
 							<calcite-button
 								key={view.id}
+								data-view-id={view.id}
 								className={`view-button ${activeViewId === view.id ? "active" : ""
 									}`}
 								title={view.name}

--- a/ABLS/src/runtime/widget.tsx
+++ b/ABLS/src/runtime/widget.tsx
@@ -1,4 +1,5 @@
 import { React, jsx } from "jimu-core"
+import ReactDOM from "react-dom"
 //import { lazy } from 'react'
 import type { AllWidgetProps } from "jimu-core"
 import { JimuMapViewComponent, type JimuMapView } from "jimu-arcgis"
@@ -9,21 +10,58 @@ import defaultMessages from "./translations/default"
 import "./style.css"
 import TimeExtent from "@arcgis/core/time/TimeExtent"
 import { useCallback } from "react"
-import { CalciteButton } from "@esri/calcite-components-react"
+import "calcite-components"
+import type Layer from "esri/layers/Layer"
+import chevronDownSvg from "jimu-icons/svg/outlined/directional/down-small.svg"
+import chevronUpSvg from "jimu-icons/svg/outlined/directional/up-small.svg"
 
 export default function Widget (props: AllWidgetProps<Config>) {
 	const { config, useMapWidgetIds } = props
 	const [jimuMapView, setJimuMapView] = React.useState<JimuMapView>(null)
 	const [activeViewId, setActiveViewId] = React.useState<string>(null)
 
+	const [expand, setExpand] = React.useState(false)
+	const [expandedLayers, setExpandedLayers] = React.useState<Layer[]>([])
+	const [visibleLayers, setVisibleLayers] = React.useState<Layer[]>([])
+	const [listStyle, setListStyle] = React.useState<React.CSSProperties>({})
+	const buttonsWrapperRef = React.useRef<HTMLDivElement>(null)
+
 	// This is the way that the widget prevents itself from running itself, and from crashing. It checks to see if any maps have been selected, and if any views have been configured.
 	const isConfigured = useMapWidgetIds?.length > 0 && config.views?.length > 0
+
+	const handleViewExpand = useCallback(
+		(view: ABLSView) => {
+			if (expand && activeViewId === view.id) {
+				setExpand(false)
+				setExpandedLayers([])
+				setVisibleLayers([])
+				return
+			}
+			if (jimuMapView?.view?.map?.allLayers) {
+				const allLayers = jimuMapView.view.map.allLayers.toArray().reverse()
+				allLayers.forEach((layer) => {
+					if (view.expandLayerIds.includes(layer.id)) {
+						setExpandedLayers((prev) => [...prev, layer])
+						if (layer.visible && !visibleLayers.includes(layer)) {
+							setVisibleLayers((prev) => [...prev, layer])
+						}
+						else if (!layer.visible && visibleLayers.includes(layer)) {
+							setVisibleLayers((prev) => prev.filter((l) => l !== layer))
+						}
+					}
+				})
+				setExpand(true)
+			}
+		},
+		[expand, activeViewId, jimuMapView, visibleLayers]
+	)
+
 
 	// The contained elements are performed every time a view button is clicked.
 	const handleViewChange = useCallback(
 		(view: ABLSView) => {
 			if (!jimuMapView || !jimuMapView.view) return
-
+			setExpand(false)
 			setActiveViewId(view.id)
 
 			// 1. Handle Layer Visibility
@@ -82,6 +120,20 @@ export default function Widget (props: AllWidgetProps<Config>) {
 	)
 
 	React.useEffect(() => {
+		if (expand && buttonsWrapperRef.current) {
+			const rect = buttonsWrapperRef.current.getBoundingClientRect()
+			const spaceAbove = rect.top
+			const spaceBelow = window.innerHeight - rect.bottom
+			const openUpward = spaceAbove >= 150 || spaceAbove >= spaceBelow
+			setListStyle(
+				openUpward
+					? { bottom: window.innerHeight - rect.top, left: rect.left }
+					: { top: rect.bottom, left: rect.left }
+			)
+		}
+	}, [expand])
+
+	React.useEffect(() => {
 		// Check if the map is loaded, if views are configured, and if no view is active yet.
 		if (jimuMapView && !activeViewId && config.views?.length > 0) {
 			// Trigger the handler for the first view in the configuration.
@@ -104,6 +156,44 @@ export default function Widget (props: AllWidgetProps<Config>) {
 		)
 	}
 
+	// Build helper structures for nested list rendering
+	const expandedLayerIds = new Set(expandedLayers.map((l) => l.id))
+
+	// Collect IDs of layers that are nested children of a group layer also in expandedLayers.
+	// These will be skipped at the top level and rendered inside their parent instead.
+	const nestedChildIds = new Set<string>()
+	expandedLayers.forEach((layer) => {
+		if (layer.type === "group") {
+			const children: Layer[] = (layer as any).layers?.toArray?.() ?? []
+			children.forEach((child) => {
+				if (expandedLayerIds.has(child.id)) {
+					nestedChildIds.add(child.id)
+				}
+			})
+		}
+	})
+
+	const renderLayerItem = (layer: Layer): React.ReactElement => {
+		if (layer.type === "group") {
+			const children: Layer[] = (layer as any).layers?.toArray?.() ?? []
+			const expandedChildren = children.filter((child) => expandedLayerIds.has(child.id))
+			if (expandedChildren.length > 0) {
+				return (
+					<calcite-list-item expanded key={layer.id} label={layer.title} selected={layer.visible} oncalciteListItemSelect={(e: Event) => { e.stopPropagation(); layer.visible = !layer.visible }}>
+						<calcite-list displayMode="nested" selectionMode="multiple" label="Group Layers">
+							{expandedChildren.map((child) => renderLayerItem(child))}
+						</calcite-list>
+					</calcite-list-item>
+				)
+			}
+		}
+		return (
+			<calcite-list-item key={layer.id} label={layer.title || layer.id} selected={layer.visible} oncalciteListItemSelect={(e: Event) => { e.stopPropagation(); layer.visible = !layer.visible }} />
+		)
+	}
+
+	const topLevelLayers = expandedLayers.filter((layer) => !nestedChildIds.has(layer.id))
+
 	// This return statement will not be run unless the widget has been set up at least to some degree. This is what actually creates the UI for the widget that is visible to the end user
 	return (
 		// Outer Div for the entire widget
@@ -117,30 +207,54 @@ export default function Widget (props: AllWidgetProps<Config>) {
 					}}
 				/>
 			)}
-			<div className="view-buttons-container">
-				{config.views.map(
-					(
-						view //The .map function creates the contained items multiple times, one button for each view in this case.
-					) => (
-						<CalciteButton
-							key={view.id}
-							className={`view-button ${
-								activeViewId === view.id ? "active" : ""
-							}`}
-							title={view.name}
-							onClick={() => {
-								handleViewChange(view)
-							}}
-							appearance={activeViewId === view.id ? "solid" : "transparent"}
-							kind={activeViewId === view.id ? "brand" : "neutral"}
-						>
-							{view.icon && (
-								<Icon icon={view.icon.svg} size="16" className="mr-2" />
-							)}
-							{view.name}
-						</CalciteButton>
-					)
+			<div className="view-buttons-wrapper" ref={buttonsWrapperRef}>
+				{expand && expandedLayers.length > 0 && ReactDOM.createPortal(
+					<calcite-list
+						label="Expanded Layers"
+						className="expanded-layers-list"
+						selectionMode="multiple"
+						displayMode="nested"
+						style={listStyle}
+					>
+						{topLevelLayers.map((layer) => renderLayerItem(layer))}
+					</calcite-list>,
+					document.body
 				)}
+				<div className="view-buttons-container">
+					{config.views.map(
+						(
+							view //The .map function creates the contained items multiple times, one button for each view in this case.
+						) => (
+							<calcite-button
+								key={view.id}
+								className={`view-button ${activeViewId === view.id ? "active" : ""
+									}`}
+								title={view.name}
+								onClick={() => {
+									if (activeViewId === view.id) {
+										handleViewExpand(view)
+										return
+									}
+									handleViewChange(view)
+								}}
+								appearance={activeViewId === view.id ? "solid" : "transparent"}
+								kind={activeViewId === view.id ? "brand" : "neutral"}
+							>
+								{view.icon && (
+									<Icon icon={view.icon.svg} size="16" className="mr-2" />
+								)}
+								{view.name}
+								{view.expandLayerIds?.length > 0 && (
+									<Icon
+										icon={expand && activeViewId === view.id ? chevronUpSvg : chevronDownSvg}
+										size="12"
+										className="expand-handle-icon"
+									/>
+								)}
+							</calcite-button>
+						)
+					)}
+				</div>
 			</div>
 		</div>
 	)

--- a/ABLS/src/setting/setting.tsx
+++ b/ABLS/src/setting/setting.tsx
@@ -39,6 +39,7 @@ export default function Setting (props: AllWidgetSettingProps<IMConfig>) {
 		onSettingChange({
 			id: id,
 			config: {
+				...config,
 				views: value
 			}
 		})
@@ -89,6 +90,22 @@ export default function Setting (props: AllWidgetSettingProps<IMConfig>) {
 		updateView(view.id, { layerIds: newLayerIds })
 	}
 
+	const onExpandLayerCheckChange = (
+		view: ABLSView,
+		layerId: string,
+		checked: boolean
+	) => {
+		let newLayerIds = view.expandLayerIds ? [...view.expandLayerIds] : []
+		if (checked) {
+			if (!newLayerIds.includes(layerId)) {
+				newLayerIds.push(layerId)
+			}
+		} else {
+			newLayerIds = newLayerIds.filter((id) => id !== layerId)
+		}
+		updateView(view.id, { expandLayerIds: newLayerIds })
+	}
+
 	return (
 		<div className="widget-setting-abls">
 			<SettingSection
@@ -117,6 +134,28 @@ export default function Setting (props: AllWidgetSettingProps<IMConfig>) {
 					onActiveViewChange={onActiveViewChange}
 				/>
 			)}
+
+			<SettingSection
+				title={props.intl.formatMessage({
+					id: "enableExpand",
+					defaultMessage: defaultMessages.enableExpand
+				})}
+			>
+				<SettingRow label="Enable Layer Expansion">
+					<Switch
+						checked={config.expandEnabled ?? false}
+						onChange={(evt) => {
+							onSettingChange({
+								id: id,
+								config: {
+									...config,
+									expandEnabled: evt.target.checked
+								}
+							})
+						}}
+					/>
+				</SettingRow>
+			</SettingSection>
 
 			{jimuMapView && (
 				<SettingSection
@@ -188,6 +227,30 @@ export default function Setting (props: AllWidgetSettingProps<IMConfig>) {
 									</SettingRow>
 								))}
 							</div>
+							{config.expandEnabled && (
+								<>
+									<SettingRow
+										flow="wrap"
+										label={props.intl.formatMessage({
+											id: "expandLayers",
+											defaultMessage: defaultMessages.expandLayers
+										})}
+									/>
+									<div className="layer-list">
+										{layers?.map((layer) => (
+											<SettingRow key={layer.id}>
+												<Checkbox
+													checked={view.expandLayerIds?.includes(layer.id)}
+													onChange={(_e, checked) => {
+														onExpandLayerCheckChange(view, layer.id, checked)
+													}}
+												/>
+												<label className="ml-2">{layer.title}</label>
+											</SettingRow>
+										))}
+									</div>
+								</>
+							)}
 							<SettingRow
 								label="Enable Time Filter"
 								className="mt-3 border-top pt-3"

--- a/ABLS/src/setting/translations/default.ts
+++ b/ABLS/src/setting/translations/default.ts
@@ -6,6 +6,8 @@ export default {
     viewName: 'View Name',
     icon: 'Icon',
     visibleLayers: 'Visible Layers',
+    enableExpand: 'Layer Expansion',
+    expandLayers: 'Layers to Expand',
     addView: '+ Add View',
     configureWidget: 'Please configure this widget in the settings panel.'
 }

--- a/ABLS/src/setting/utils.ts
+++ b/ABLS/src/setting/utils.ts
@@ -4,9 +4,62 @@ import type Layer from 'esri/layers/Layer'
 
 export function getLayersFromJimuMapView (jimuMapView: JimuMapView): Layer[] {
     const layers: Layer[] = []
-    const collectLayers = (layerCollection: { forEach: (callback: (layer: any) => void) => void }) => {
-        layerCollection.forEach((layer: any) => {
+    const seenLayerKeys = new Set<string>()
+    const seenLayerRefs = new WeakSet()
+
+    const toLayerArray = (layerCollection: any): any[] => {
+        if (!layerCollection) {
+            return []
+        }
+        if (Array.isArray(layerCollection)) {
+            return layerCollection
+        }
+        if (typeof layerCollection.toArray === 'function') {
+            return layerCollection.toArray()
+        }
+        if (typeof layerCollection.forEach === 'function') {
+            const collectionItems: any[] = []
+            layerCollection.forEach((layer: any) => collectionItems.push(layer))
+            return collectionItems
+        }
+        return []
+    }
+
+    const getLayerKey = (layer: any): string | null => {
+        if (!layer) {
+            return null
+        }
+        if (layer.uid != null) {
+            return `uid:${String(layer.uid)}`
+        }
+        if (layer.id != null && layer.type != null) {
+            return `type:${String(layer.type)}|id:${String(layer.id)}`
+        }
+        if (layer.id != null) {
+            return `id:${String(layer.id)}`
+        }
+        return null
+    }
+
+    const collectLayers = (layerCollection: any): void => {
+        toLayerArray(layerCollection).forEach((layer: any) => {
+            const layerKey = getLayerKey(layer)
+            const isSeenByKey = layerKey ? seenLayerKeys.has(layerKey) : false
+            const isSeenByRef = layer && typeof layer === 'object' ? seenLayerRefs.has(layer) : false
+
+            if (isSeenByKey || isSeenByRef) {
+                return
+            }
+
+            if (layerKey) {
+                seenLayerKeys.add(layerKey)
+            }
+            if (layer && typeof layer === 'object') {
+                seenLayerRefs.add(layer)
+            }
+
             layers.push(layer)
+
             if (layer.layers) {
                 collectLayers(layer.layers)
             }
@@ -15,8 +68,11 @@ export function getLayersFromJimuMapView (jimuMapView: JimuMapView): Layer[] {
             }
         })
     }
-    if (jimuMapView?.view?.map?.allLayers) {
-        collectLayers(jimuMapView.view.map.allLayers)
-    }
+
+    // Follow the same map.layers-first approach used by new-radar, while still
+    // traversing nested layers/sublayers for ABLS backward compatibility.
+    const rootLayers = jimuMapView?.view?.map?.allLayers ?? jimuMapView?.view?.map?.layers
+    collectLayers(rootLayers)
+
     return layers
 }


### PR DESCRIPTION
This update allows for more granularity in the user interaction when switching between different layer views. Maybe you're trying to show different types of information (Fire, Water, Infrastructure) but when showing these different types, there's still too much information in one category. With this update, you can still choose a default view, but then provide more user interactivity as far as what specific layers within a category are desired, without having to force users to dig through a massive layer list.