### PR TITLE
Updated CamViewer to allow multiple cameras to be visible at once.

### DIFF
--- a/CamViewer/README.md
+++ b/CamViewer/README.md
@@ -16,6 +16,8 @@ This widget can be used and interacted with on my example application, found [he
 
 This widget can be set up by adding the widget to your application, then selecting the map and data source the camera layer is stored in. You will then select the field that the .m3u8 url is stored in, as well as an icon for the main widget button. It is recommended that you set a background color in the style settings, and also set the height and width to "auto".
 
+As of `v1.0.2` The builder can also choose to allow multiple feeds to be opened at the same time by the user. This will display a popup above the button to turn on the layer, allowing the user to switch the camera viewer into multi-feed mode. This is designed to be backwards compatible with existing uses of the CamViewer widget.
+
 ## Using the widget
 
 Click the widget button (Icon selected by builder), and cameras should appear on your map. Click a camera icon on your map, and a viewing window should appear. You can then click the X icon in the top right of the camera window to close the camera feed and unselect the camera feature/features.

--- a/CamViewer/config.json
+++ b/CamViewer/config.json
@@ -1,3 +1,4 @@
 {
-  "icon": "camera"
+  "icon": "camera",
+  "multiple": false
 }

--- a/CamViewer/package-lock.json
+++ b/CamViewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exb-camviewer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exb-camviewer",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "hls.js": "^1.6.15"

--- a/CamViewer/package.json
+++ b/CamViewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exb-camviewer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A camera viewer, to view .m3u8 streams via a url in a feature layer.",
   "license": "MIT",
   "author": "Lucius Creamer",

--- a/CamViewer/src/config.ts
+++ b/CamViewer/src/config.ts
@@ -3,6 +3,7 @@ import type { IconResult } from 'jimu-core'
 
 export interface Config {
   icon: IconResult;
+  multiple: boolean;
 }
 
 export type IMConfig = ImmutableObject<Config>

--- a/CamViewer/src/runtime/widget.tsx
+++ b/CamViewer/src/runtime/widget.tsx
@@ -7,59 +7,73 @@ import { Button, Icon } from 'jimu-ui'
 import './style.css'
 import { useCallback, useState } from 'react'
 import { createPortal } from 'react-dom'
-
 // You need to install hls.js into your client directory
 // Run npm install hls.js in your client directory to install.
 import Hls from 'hls.js'
-
-export default function Widget (props: AllWidgetProps<IMConfig>) {
-  const { useDataSources, useMapWidgetIds } = props
-  const [jimuMapView, setJimuMapView] = React.useState<JimuMapView>(null)
-
-  const isConfigured = useDataSources && useDataSources.length > 0 && useDataSources[0].dataSourceId && useDataSources[0].fields && useDataSources[0].fields.length > 0
-
-  // Dedicated state for currentURL and layerView
-  const [currentURL, setCurrentURL] = React.useState<string | undefined>(undefined)
-  const [layerView, setLayerView] = React.useState<JimuLayerView | undefined>(undefined)
-  const [camLayerOn, setCamLayerOn] = React.useState(false)
-  const [ds, setDs] = useState<DataSource>(null)
+import 'calcite-components'
 
 
-  // State for video position and size
-  const [videoPos, setVideoPos] = useState({ x: 100, y: 100 })
+interface FeedData {
+  id: string
+  url: string
+  initialPos: { x: number, y: number }
+}
+
+interface CameraFeedProps {
+  feed: FeedData
+  onClose: (id: string, url: string) => void
+}
+
+function CameraFeed ({ feed, onClose }: CameraFeedProps) {
+  const [pos, setPos] = useState(feed.initialPos)
+  const [size, setSize] = useState({ width: 250, height: 140 })
   const [dragging, setDragging] = useState(false)
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
   const [resizing, setResizing] = useState(false)
   const [resizeStart, setResizeStart] = useState({ x: 0, y: 0, width: 250, height: 140 })
-  const [videoSize, setVideoSize] = useState({ width: 250, height: 140 })
-  const [showVideo, setShowVideo] = useState(true)
   const [aspectRatio, setAspectRatio] = useState(16 / 9)
+  const videoRef = React.useRef<HTMLVideoElement>(null)
 
-  const dataRender = (ds: DataSource) => {
-    const selectedRecords = ds.getSelectedRecords()
-    const fieldanme = props.useDataSources[0].fields[0]
-    if (selectedRecords.length > 0) {
-      const url = selectedRecords[0].getFieldValue(fieldanme)
-      setCurrentURL(url)
-      setShowVideo(true)
+  React.useEffect(() => {
+    if (!videoRef.current) return
+    const video = videoRef.current
+    if (Hls.isSupported()) {
+      const hls = new Hls()
+      hls.loadSource(feed.url)
+      hls.attachMedia(video)
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        video.play().catch(err => { console.warn('Autoplay prevented:', err) })
+      })
+      hls.on(Hls.Events.ERROR, (_event, data) => {
+        console.warn('HLS error:', data)
+      })
+      return () => { hls.destroy() }
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      // Safari: native HLS support
+      video.src = feed.url
+      video.play().catch(err => { console.warn('Autoplay prevented:', err) })
+    } else {
+      // Fallback for direct video URLs (MP4, etc.)
+      video.src = feed.url
     }
-  }
+  }, [feed.url])
 
-  // Draggable, resizable, closable video portal
-  const handleMouseMove = (e: MouseEvent) => {
+  const handleMouseMove = React.useCallback((e: MouseEvent) => {
     if (dragging) {
-      setVideoPos({ x: e.clientX - dragOffset.x, y: e.clientY - dragOffset.y })
+      setPos({ x: e.clientX - dragOffset.x, y: e.clientY - dragOffset.y })
     } else if (resizing) {
       const dx = e.clientX - resizeStart.x
       const newWidth = Math.max(120, resizeStart.width + dx)
       const newHeight = Math.round(newWidth / aspectRatio)
-      setVideoSize({ width: newWidth, height: newHeight })
+      setSize({ width: newWidth, height: newHeight })
     }
-  }
-  const handleMouseUp = () => {
+  }, [dragging, dragOffset, resizing, resizeStart, aspectRatio])
+
+  const handleMouseUp = React.useCallback(() => {
     setDragging(false)
     setResizing(false)
-  }
+  }, [])
+
   React.useEffect(() => {
     if (dragging || resizing) {
       window.addEventListener('mousemove', handleMouseMove)
@@ -69,14 +83,14 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
         window.removeEventListener('mouseup', handleMouseUp)
       }
     }
-  })
+  }, [dragging, resizing, handleMouseMove, handleMouseUp])
 
-  const videoPortal = (currentURL && showVideo) ? createPortal(
+  return createPortal(
     <div
       style={{
         position: 'fixed',
-        left: videoPos.x,
-        top: videoPos.y,
+        left: pos.x,
+        top: pos.y,
         zIndex: 9999,
         cursor: dragging ? 'grabbing' : 'grab',
         background: 'rgba(0,0,0,0.2)',
@@ -88,10 +102,9 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
         minHeight: 68
       }}
       onMouseDown={e => {
-        // Only drag if not clicking close or resize
         if ((e.target as HTMLElement).classList.contains('video-close-btn') || (e.target as HTMLElement).classList.contains('video-resize-handle')) return
         setDragging(true)
-        setDragOffset({ x: e.clientX - videoPos.x, y: e.clientY - videoPos.y })
+        setDragOffset({ x: e.clientX - pos.x, y: e.clientY - pos.y })
       }}
     >
       {/* Close button */}
@@ -113,25 +126,21 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
           cursor: 'pointer',
           zIndex: 2
         }}
-        onClick={() => {
-          ds.clearSelection()
-          setShowVideo(false)
-        }}
+        onClick={() => { onClose(feed.id, feed.url) }}
         title="Close"
       >×</div>
       {/* Video */}
       <video
-        src={currentURL}
+        ref={videoRef}
         autoPlay={true}
-        style={{ width: videoSize.width, height: videoSize.height, borderRadius: 10, display: 'block' }}
+        style={{ width: size.width, height: size.height, borderRadius: 10, display: 'block' }}
         className={'cameraViewer-video'}
         onLoadedMetadata={e => {
           const video = e.currentTarget
           if (video.videoWidth && video.videoHeight) {
             const ratio = video.videoWidth / video.videoHeight
             setAspectRatio(ratio)
-            // Optionally, update window size to match new aspect ratio
-            setVideoSize(prev => ({ width: prev.width, height: Math.round(prev.width / ratio) }))
+            setSize(prev => ({ width: prev.width, height: Math.round(prev.width / ratio) }))
           }
         }}
       />
@@ -155,15 +164,192 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
         onMouseDown={e => {
           e.stopPropagation()
           setResizing(true)
-          setResizeStart({ x: e.clientX, y: e.clientY, width: videoSize.width, height: videoSize.height })
+          setResizeStart({ x: e.clientX, y: e.clientY, width: size.width, height: size.height })
         }}
         title="Resize"
       >
-        <svg width="16" height="16" viewBox="0 0 16 16"><polyline points="4,16 16,4" stroke="#fff" strokeWidth="2" fill="none"/></svg>
+        <svg width="16" height="16" viewBox="0 0 16 16"><polyline points="4,16 16,4" stroke="#fff" strokeWidth="2" fill="none" /></svg>
       </div>
     </div>,
     document.body
+  )
+}
+
+export default function Widget (props: AllWidgetProps<IMConfig>) {
+  const { useDataSources, useMapWidgetIds } = props
+  const [jimuMapView, setJimuMapView] = React.useState<JimuMapView>(null)
+
+  const isConfigured = useDataSources && useDataSources.length > 0 && useDataSources[0].dataSourceId && useDataSources[0].fields && useDataSources[0].fields.length > 0
+
+  const [layerView, setLayerView] = React.useState<JimuLayerView | undefined>(undefined)
+  const [camLayerOn, setCamLayerOn] = React.useState(false)
+  const [feeds, setFeeds] = useState<FeedData[]>([])
+  // Tracks which URLs are currently open so we don't open the same feed twice
+  const openUrlsRef = React.useRef<Set<string>>(new Set())
+  const dsRef = React.useRef<DataSource>(null)
+
+  // Multiple-mode toggle
+  const [multipleMode, setMultipleMode] = useState(false)
+  const multipleModeRef = React.useRef(true)
+  const [controlsAbove, setControlsAbove] = useState(false)
+  const wrapperRef = React.useRef<HTMLDivElement>(null)
+  const popupRef = React.useRef<HTMLDivElement>(null)
+  const closePopupTimerRef = React.useRef<number | undefined>(undefined)
+  const [popupPos, setPopupPos] = useState({ left: 0, top: 0 })
+  const [showPopup, setShowPopup] = useState(false)
+
+  const dataRender = (ds: DataSource) => {
+    dsRef.current = ds
+    const selectedRecords = ds.getSelectedRecords()
+    const fieldName = props.useDataSources[0].fields[0]
+    if (selectedRecords.length > 0) {
+      const url = selectedRecords[0].getFieldValue(fieldName) as string
+      if (url && !openUrlsRef.current.has(url)) {
+        if (!multipleModeRef.current) {
+          // Single mode: replace all existing feeds with this one
+          openUrlsRef.current = new Set([url])
+          setFeeds([{ id: `feed-${Date.now()}`, url, initialPos: { x: 100, y: 100 } }])
+        } else {
+          // Multiple mode: add a new feed offset from existing ones
+          openUrlsRef.current.add(url)
+          const offset = openUrlsRef.current.size - 1
+          setFeeds(prev => [...prev, {
+            id: `feed-${Date.now()}`,
+            url,
+            initialPos: { x: 100 + offset * 30, y: 100 + offset * 30 }
+          }])
+        }
+      }
+    }
+  }
+
+  // Keep multipleModeRef in sync whenever the switch changes
+  React.useEffect(() => {
+    multipleModeRef.current = multipleMode
+  }, [multipleMode])
+
+  // If multiple support is disabled in widget config, force single mode and hide popup.
+  React.useEffect(() => {
+    if (props.config?.multiple) return
+    setMultipleMode(false)
+    setShowPopup(false)
+  }, [props.config?.multiple])
+
+  // If user turns multiple mode off while several feeds are open, keep only one.
+  React.useEffect(() => {
+    if (multipleMode || feeds.length <= 1) return
+    const ds = dsRef.current
+    const fieldName = props.useDataSources[0].fields[0]
+    let keepUrl: string | undefined
+    if (ds) {
+      const selected = ds.getSelectedRecords()
+      if (selected.length > 0) {
+        keepUrl = selected[0].getFieldValue(fieldName) as string
+      }
+    }
+    const fallbackUrl = keepUrl ?? feeds[feeds.length - 1]?.url
+    if (!fallbackUrl) return
+    openUrlsRef.current = new Set([fallbackUrl])
+    setFeeds([{ id: `feed-${Date.now()}`, url: fallbackUrl, initialPos: { x: 100, y: 100 } }])
+  }, [multipleMode, feeds, props.useDataSources])
+
+  const updatePopupPosition = useCallback(() => {
+    if (!wrapperRef.current) return
+    const rect = wrapperRef.current.getBoundingClientRect()
+    const popupHeight = 38
+    const gap = 6
+    const spaceAbove = rect.top
+    const spaceBelow = window.innerHeight - rect.bottom
+    const placeAbove = spaceBelow < popupHeight + gap && spaceAbove > popupHeight + gap
+    setControlsAbove(placeAbove)
+    setPopupPos({
+      left: rect.left + rect.width / 2,
+      top: placeAbove ? rect.top - gap : rect.bottom + gap
+    })
+  }, [])
+
+  // Recalculate popup placement whenever it opens, and while viewport changes.
+  React.useLayoutEffect(() => {
+    if (!showPopup) return
+    updatePopupPosition()
+    const handleLayout = () => { updatePopupPosition() }
+    window.addEventListener('resize', handleLayout)
+    window.addEventListener('scroll', handleLayout, true)
+    return () => {
+      window.removeEventListener('resize', handleLayout)
+      window.removeEventListener('scroll', handleLayout, true)
+    }
+  }, [showPopup, updatePopupPosition])
+
+  const cancelClosePopupTimer = useCallback(() => {
+    if (closePopupTimerRef.current !== undefined) {
+      window.clearTimeout(closePopupTimerRef.current)
+      closePopupTimerRef.current = undefined
+    }
+  }, [])
+
+  const scheduleClosePopup = useCallback(() => {
+    cancelClosePopupTimer()
+    closePopupTimerRef.current = window.setTimeout(() => {
+      setShowPopup(false)
+    }, 150)
+  }, [cancelClosePopupTimer])
+
+  React.useEffect(() => {
+    return () => {
+      cancelClosePopupTimer()
+    }
+  }, [cancelClosePopupTimer])
+
+  const modePopup = (props.config?.multiple && showPopup) ? createPortal(
+    <div
+      ref={popupRef}
+      onMouseEnter={() => {
+        cancelClosePopupTimer()
+        setShowPopup(true)
+      }}
+      onMouseLeave={() => {
+        scheduleClosePopup()
+      }}
+      style={{
+        position: 'fixed',
+        left: popupPos.left,
+        top: popupPos.top,
+        transform: controlsAbove ? 'translate(-50%, -100%)' : 'translateX(-50%)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '6px 10px',
+        background: 'var(--calcite-color-foreground-1, #fff)',
+        borderRadius: 6,
+        boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+        zIndex: 20000,
+        whiteSpace: 'nowrap'
+      }}
+    >
+      <span style={{ fontSize: 12 }}>Multiple</span>
+      <calcite-switch
+        scale="s"
+        checked={multipleMode}
+        oncalciteSwitchChange={(e: any) => { setMultipleMode(Boolean(e.target?.checked)) }}
+      />
+    </div>,
+    document.body
   ) : null
+
+  const closeFeed = useCallback((id: string, url: string) => {
+    openUrlsRef.current.delete(url)
+    setFeeds(prev => prev.filter(f => f.id !== id))
+    // If the closed feed's URL is the currently selected feature, deselect it
+    const ds = dsRef.current
+    if (ds) {
+      const fieldName = props.useDataSources[0].fields[0]
+      const selected = ds.getSelectedRecords()
+      if (selected.length > 0 && selected[0].getFieldValue(fieldName) === url) {
+        ds.clearSelection()
+      }
+    }
+  }, [props.useDataSources])
 
   const activeViewChangeHandler = (jmv: JimuMapView): void => {
     if (jmv) {
@@ -179,7 +365,6 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
     const newVal = !camLayerOn
     setCamLayerOn(newVal)
     layerView.view.set({ visible: newVal })
-    console.log('Layer visibility toggled:', newVal)
   }, [jimuMapView, props.useDataSources, layerView, camLayerOn])
 
   React.useEffect(() => {
@@ -192,27 +377,8 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
       setLayerView(jimuLayerView)
       setCamLayerOn(false)
       jimuLayerView.layer.set({ visible: false })
-      console.log('Layer visibility turned off (Default):', false)
     }
   }, [jimuMapView, props.useDataSources, layerView])
-
-  React.useEffect(() => {
-    console.log("useEffect called")
-    const hls = new Hls({ debug: true })
-    console.log("HLS instance created:", hls)
-    if (Hls.isSupported() && currentURL) {
-      hls.loadSource(currentURL)
-      hls.on(Hls.Events.ERROR, (err) => {
-        console.log(err)
-      })
-    } else {
-      console.log("load")
-    }
-    return () => {
-      hls.destroy()
-      console.log("HLS instance destroyed")
-    }
-  }, [currentURL])
 
   if (!isConfigured) {
     return (
@@ -233,27 +399,41 @@ export default function Widget (props: AllWidgetProps<IMConfig>) {
             onActiveViewChange={activeViewChangeHandler}
           />
         )}
-        <div className="view-button">
-          <Button
-            aria-label="Button"
-            icon
-            onClick={toggleLayerVisibility}
-            size="default"
-          >
-            <Icon icon={props.config.icon.svg} size="l" />
-          </Button>
+        <div
+          ref={wrapperRef}
+          onMouseEnter={() => {
+            if (!props.config?.multiple) return
+            cancelClosePopupTimer()
+            setShowPopup(true)
+          }}
+          onMouseLeave={() => {
+            if (!props.config?.multiple) return
+            scheduleClosePopup()
+          }}
+          style={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+        >
+          <div className="view-button">
+            <Button
+              aria-label="Button"
+              icon
+              onClick={toggleLayerVisibility}
+              size="default"
+            >
+              <Icon icon={props.config.icon.svg} size="l" />
+            </Button>
+          </div>
         </div>
         <DataSourceComponent useDataSource={props.useDataSources[0]} query={{ where: '1=1' } as FeatureLayerQueryParams} widgetId={props.id}>
-          {
-            (ds: DataSource) => {
-              dataRender(ds)
-              setDs(ds)
+          {(ds: DataSource) => {
+            dataRender(ds)
             return null
-            }
-          }
+          }}
         </DataSourceComponent>
       </div>
-      {videoPortal}
+      {feeds.map(feed => (
+        <CameraFeed key={feed.id} feed={feed} onClose={closeFeed} />
+      ))}
+      {modePopup}
     </>
   )
 }

--- a/CamViewer/src/setting/setting.tsx
+++ b/CamViewer/src/setting/setting.tsx
@@ -10,6 +10,7 @@ import {
 	SettingRow,
 	SettingSection
 } from "jimu-ui/advanced/setting-components"
+import { Switch } from "jimu-ui"
 import defaultI18nMessages from "./translations/default"
 import type { IMConfig } from "../config"
 import {
@@ -64,15 +65,31 @@ export default function Setting (props: AllWidgetSettingProps<IMConfig>) {
 				})}
 			>
 				<SettingRow>
+					<MapWidgetSelector
+						onSelect={onMapSelected}
+						useMapWidgetIds={props.useMapWidgetIds}
+					/>
+				</SettingRow>
+				<SettingRow>
 					<IconPicker
 						icon={props.config?.icon as any}
 						onChange={onIconChange}
 					/>
 				</SettingRow>
-				<SettingRow>
-					<MapWidgetSelector
-						onSelect={onMapSelected}
-						useMapWidgetIds={props.useMapWidgetIds}
+				<SettingRow
+					label={"Enable Multiple Camera Support"}
+				>
+					<Switch
+						checked={props.config?.multiple || false}
+						onChange={() => {
+							props.onSettingChange({
+								id: props.id,
+								config: {
+									...props.config,
+									multiple: !props.config?.multiple
+								}
+							})
+						}}
 					/>
 				</SettingRow>
 				<SettingRow>


### PR DESCRIPTION
Adding a new setting to the CamViewer widget, to enable builders to decide if a user should be able to view multiple feeds at once. The end user can still decide to use the widget in "Single feed" mode or "Multiple" mode, which will change how the videos are displayed.